### PR TITLE
Airbus A320 (MSFS) and $ per NM

### DIFF
--- a/code.js
+++ b/code.js
@@ -18,7 +18,8 @@ tableColsAndValueKeys = {
     "From": "fromIcao",
     "To": "toIcao",
     "Distance": "distance",
-    "Pay": "pay"
+    "Pay": "pay",
+    "$ per NM": "payPerNM"
 }
 
 // main function called on document load
@@ -240,13 +241,18 @@ function handle_missions_get(planeids){
                 from_latlon = icaodata[fromIcao];
                 to_latlon = icaodata[toIcao];
 
+                distance = getDistance(from_latlon, to_latlon);
+                pay = m[header.indexOf("Pay")];
+                payPerNM = (pay / distance).toFixed(2)
+
                 missions.push({
                     "fromIcao": fromIcao,
                     "toIcao": toIcao,
                     "fromLatLon": from_latlon,
                     "toLatLon": to_latlon,
-                    "distance": getDistance(from_latlon, to_latlon),
-                    "pay": m[header.indexOf("Pay")]
+                    "distance": distance,
+                    "pay": pay,
+                    "payPerNM":  payPerNM
                 })
             }  
         }
@@ -438,6 +444,7 @@ function addRowsToTable(){
         <td><a href="https://server.fseconomy.net/airport.jsp?icao=${mission[tableColsAndValueKeys['To']]}" target="_blank">${mission[tableColsAndValueKeys['To']]}</a></td>
         <td>${Math.round(mission[tableColsAndValueKeys['Distance']])} NM</td>
         <td>\$${Math.round(mission[tableColsAndValueKeys['Pay']])}</td>
+        <td>\$${ mission[tableColsAndValueKeys['$ per NM']] } </td>
         </tr>
         `
         $("#mission-table").append(tr_string)

--- a/code.js
+++ b/code.js
@@ -1,6 +1,7 @@
 
 const planes = [
     "Airbus A320",
+    "Airbus A320 (MSFS)",
     "Airbus A321",
     "BAe 146-100 (Avro RJ70)",
     "Boeing 727-100/200",

--- a/helpers.js
+++ b/helpers.js
@@ -56,8 +56,18 @@ function getDistance(origin, destination) {
 // returns closure that sorts list by key
 function sorterBy(key, desc){
     return function(a,b) {
+        // Put the relevant variables into i and j
+        i = a[key]
+        j = b[key]
+
+        // Convert i and j to numbers if they can be converted to them
+        if( !isNaN(i) && !isNaN(j) ) {
+            i = Number(i)
+            j = Number(j)
+        }
+
         r = 1
-        if ( b[key] > a[key] ) {
+        if (i > j) {
             r = -1
         }
         if ( desc ) {

--- a/helpers.js
+++ b/helpers.js
@@ -67,7 +67,7 @@ function sorterBy(key, desc){
         }
 
         r = 1
-        if (i > j) {
+        if (i < j) {
             r = -1
         }
         if ( desc ) {

--- a/index.html
+++ b/index.html
@@ -37,8 +37,7 @@
 				<p>Get your access key from FSEconomy <a href="https://server.fseconomy.net/datafeeds.jsp">here</a>.</p>
 			</div>
 			<div class="modal-footer">
-			<button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-			<button type="button" class="btn btn-primary">Save changes</button>
+			<button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
 			</div>
 		</div>
 		</div>


### PR DESCRIPTION
This pull requests adds the new `Airbus A320 (MSFS)` as an option and removes the "Save Changes" button from the access key modal that didn't seem to do anything. 

Also added is a new column to the table that shows $ per NM for each job. I had to change the `sorterBy` for that to work properly (it sorted numbers alphabetically). Here is a screenshot of the functionality:
![image](https://user-images.githubusercontent.com/1809198/91042989-02904d80-e613-11ea-8224-4e0add3f0883.png)
